### PR TITLE
add gfl host override

### DIFF
--- a/weaviate/client_base.py
+++ b/weaviate/client_base.py
@@ -83,6 +83,7 @@ class _WeaviateClientInit:
             proxies=config.proxies,
             trust_env=config.trust_env,
             loop=self._loop,
+            gfl_host=config.gfl_host
         )
 
         self.integrations = _Integrations(self._connection)

--- a/weaviate/collections/gfl/gfl.py
+++ b/weaviate/collections/gfl/gfl.py
@@ -37,7 +37,7 @@ class _GFLBase:
     def __init__(self, connection: ConnectionV4, name: str):
         self._connection = connection
         self._name = name
-        self._gfl_host = "https://gfl.labs.weaviate.io"
+        self._gfl_host = connection.gfl_host or "https://gfl.labs.weaviate.io"
         self._cluster_host = connection.url.replace(":443", "")
         self._headers = {"Content-Type": "application/json"}
         self._headers.update(connection.additional_headers)

--- a/weaviate/config.py
+++ b/weaviate/config.py
@@ -81,6 +81,7 @@ class AdditionalConfig(BaseModel):
     proxies: Union[str, Proxies, None] = Field(default=None)
     timeout_: Union[Tuple[int, int], Timeout] = Field(default_factory=Timeout, alias="timeout")
     trust_env: bool = Field(default=False)
+    gfl_host: str | None = None
 
     @property
     def timeout(self) -> Timeout:

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -102,6 +102,7 @@ class ConnectionV4(_ConnectionBase):
         connection_config: ConnectionConfig,
         loop: asyncio.AbstractEventLoop,  # required for background token refresh
         embedded_db: Optional[EmbeddedV4] = None,
+        gfl_host: str = None
     ):
         self.url = connection_params._http_url
         self.embedded_db = embedded_db
@@ -119,6 +120,7 @@ class ConnectionV4(_ConnectionBase):
         self._grpc_max_msg_size: Optional[int] = None
         self.__connected = False
         self.__loop = loop
+        self.gfl_host = gfl_host
 
         self._headers = {"content-type": "application/json"}
         self.__add_weaviate_embedding_service_header(connection_params.http.host)


### PR DESCRIPTION
For local development and for dev/prod separation later on.

usage:
```
from weaviate import connect_to_weaviate_cloud
from weaviate.auth import AuthApiKey
from weaviate.config import AdditionalConfig

client = connect_to_weaviate_cloud(
    "cluster-url",
    AuthApiKey("api-key"),
    additional_config=AdditionalConfig(gfl_host="http://localhost:8000"),
)
```
